### PR TITLE
Fixing Minor Bugs.

### DIFF
--- a/Assets/GILES/Code/Classes/GUI/Type Inspectors/pb_ObjectInspector.cs
+++ b/Assets/GILES/Code/Classes/GUI/Type Inspectors/pb_ObjectInspector.cs
@@ -15,7 +15,7 @@ namespace GILES.Interface
 	{
 		object value;
 		
-		private static readonly RectOffset RectOffset_Zero = new RectOffset(0,0,0,0);
+		//private static readonly RectOffset RectOffset_Zero = new RectOffset(0,0,0,0);
 		private const int VERTICAL_LAYOUT_SPACING = 0;
 
 		void OnGUIChanged()
@@ -27,7 +27,7 @@ namespace GILES.Interface
 		{
 			value = GetValue<object>();
 
-			pb_GUIUtility.AddVerticalLayoutGroup(gameObject, RectOffset_Zero, VERTICAL_LAYOUT_SPACING, true, false);
+			pb_GUIUtility.AddVerticalLayoutGroup(gameObject, new RectOffset(0,0,0,0), VERTICAL_LAYOUT_SPACING, true, false);
 
 			BuildInspectorTree();
 		}

--- a/Assets/GILES/Code/Classes/GUI/pb_GUIUtility.cs
+++ b/Assets/GILES/Code/Classes/GUI/pb_GUIUtility.cs
@@ -93,7 +93,9 @@ namespace GILES.Interface
 			GameObject go = new GameObject();
 			go.name = "Label Field";
 			Text field = go.AddComponent<Text>();
-			field.text = text;
+			string temp = text.Replace("UnityEngine.","");
+			field.text = temp; //This removes the UnityEngine. Prefix from the Inspector.
+			//field.text = text;
 			field.font = pb_GUIUtility.DefaultFont();
 			go.AddComponent<LayoutElement>().minHeight = 24;
 			field.alignment = TextAnchor.MiddleLeft;


### PR DESCRIPTION
Fixed a bug which didn't allow for change in The Light GameObject Properties in Unity 2017.4 and also remove the "UnityEngine." prefix from the Label Field objects, so now instead of Showing - UnityEngine.Transform / UnityEngine.Light. Now it shows only Light and Transform.